### PR TITLE
열림 닫힘만 나타내는 문자열을 Boolean타입으로 변경하라

### DIFF
--- a/src/SideBar.jsx
+++ b/src/SideBar.jsx
@@ -24,7 +24,7 @@ export default function SideBarMenu({ isPc, callSideBarMenu }) {
     <>
       {isPc ?
         <WebSideBarMenu /> :
-        callSideBarMenu == 'true' ?
+        callSideBarMenu ?
           <MobileSideBarMenu
             onClickClose={handleClickClose}
           />

--- a/src/slice.js
+++ b/src/slice.js
@@ -58,20 +58,20 @@ const { actions, reducer } = createSlice({
     randomSituationPlaceRestaurants: [],
     randomAgeCategoryRestaurants: [],
 
-    callSideBarMenu: '',
+    callSideBarMenu: false,
   },
   reducers: {
     setSideBarMenu(state) {
       return {
         ...state,
-        callSideBarMenu: 'true',
+        callSideBarMenu: true,
       }
     },
 
     removeSideBarMenu(state) {
       return {
         ...state,
-        callSideBarMenu: '',
+        callSideBarMenu: false,
       }
     },
 


### PR DESCRIPTION
callSideBarMenu는 사이드 바를 보여주고 안보여주고를 하는데 사용되는 변수입니다.
그런데 이러한 데이터를 문자열로 관리하고 있었습니다.
열림 닫힘 두 가지의 타입만을 나타내는 변수이므로 Boolean타입의 변수를 사용하는게 더 적절합니다.
따라서 Boolean타입의 변수로 변경하였습니다. 문자열로 true를 직접 비교하는 것도 삭제했습니다.