### PR TITLE
사이드바가 상단에서 분리되는 것을 고치라

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
     'comma-style': ['error', 'last'],
     'comma-dangle': ['error', 'always-multiline'],
     'space-in-parens': ['error', 'never'],
+    'semi': [2, 'always'],
     'block-spacing': 'error',
     'array-bracket-spacing': ['error', 'never'],
     'object-curly-spacing': ['error', 'always'],
@@ -51,4 +52,4 @@ module.exports = {
     },
   },
   "ignorePatterns": ["main.js", "node_modules/", "bootstrap.bundle.min.js", "assets/js/"],
-}
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint --ext js,jsx .",
     "build": "webpack --mode production",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist --remote upstream"
+    "deploy": "echo 'superduper-india.codesoom.com' > ./dist/CNAME && gh-pages -d dist --remote upstream"
   },
   "repository": {
     "type": "git",
@@ -33,13 +33,14 @@
     "babel-loader": "^8.2.3",
     "eslint": "^8.7.0",
     "eslint-plugin-react": "^7.28.0",
+    "gh-pages": "^4.0.0",
     "jest": "^27.4.7",
     "jest-plugin-context": "^2.7.0",
+    "lodash.filter": "^4.6.0",
+    "lodash.uniqby": "^4.7.0",
     "webpack": "^5.67.0",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.7.3",
-    "lodash.filter": "^4.6.0",
-    "lodash.uniqby": "^4.7.0"
+    "webpack-dev-server": "^4.7.3"
   },
   "dependencies": {
     "@emotion/react": "^11.7.1",

--- a/src/slice.js
+++ b/src/slice.js
@@ -52,7 +52,9 @@ const { actions, reducer } = createSlice({
     afterBars: [],
     RecommenedCourse: [],
 
-    searchField: {},
+    searchField: {
+      searchKeyword: '',
+    },
     searchKeyword: '',
     moodRestaurantsData: {},
     randomSituationPlaceRestaurants: [],

--- a/src/styles/MobileSideBarMenuStyle.jsx
+++ b/src/styles/MobileSideBarMenuStyle.jsx
@@ -6,6 +6,7 @@ export const MobileSideBarMenuStyle = styled.div({
   height: '100vh',
   width: '73vw',
   position: 'fixed',
+  top: 0,
   left: 0,
   zIndex: 1,
   display: 'flex',

--- a/src/styles/MobileSlimSideBarStyle.jsx
+++ b/src/styles/MobileSlimSideBarStyle.jsx
@@ -6,6 +6,7 @@ export const MobileSlimSideBarStyle = styled.div({
   height: '100vh',
   width: '15.5vw',
   position: 'fixed',
+  top: 0,
   left: 0,
   zIndex: 1,
   display: 'flex',

--- a/src/styles/WebSideBarMenuStyle.jsx
+++ b/src/styles/WebSideBarMenuStyle.jsx
@@ -10,6 +10,7 @@ export const WebSideBarMenuStyle = styled.div({
   height: '100vh',
   width: '18.75rem',
   position: 'fixed',
+  top: 0,
   left: 0,
   zIndex: 1,
   display: 'flex',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const dotenv = require('dotenv-webpack');
 
 module.exports = {
   mode: 'development',
@@ -27,6 +26,5 @@ module.exports = {
     port: 8080,
   },
   plugins: [
-    new dotenv(),
   ],
 };


### PR DESCRIPTION
검색페이지에서 사이드바가 화면상단에서 분리됩니다.
사이드바의 스타일 컴포넌트에 top속성을 추가해서 고쳤습니다.
그 외에 에러를 해결하기 위해 webpack.config.js 에서  코드를 삭제하고, slice.js 에서 코드를 추가했습니다.
그리고 배포했을때 도메인을 수동으로 설정해줘야하는 부분을 해결하기 위해서 package.json 배포 설정을 수정했습니다.
그리고 자동으로 세미콜론을 추가하기 위해서 eslintrc.js 설정을 추가했습니다.